### PR TITLE
Add Kronstorf, Austria data center

### DIFF
--- a/src/static/data/gcp-regions.json
+++ b/src/static/data/gcp-regions.json
@@ -272,13 +272,6 @@
     "lng": -6.4494116
   },
   {
-    "id": "europe-westX-austria",
-    "locationName": "Austria",
-    "lat": 48.2082,
-    "lng": 16.3738,
-    "approximate": true
-  },
-  {
     "id": "europe-westX-kronstorf",
     "locationName": "Kronstorf, Austria",
     "lat": 48.119927,

--- a/src/static/data/gcp-regions.json
+++ b/src/static/data/gcp-regions.json
@@ -279,6 +279,12 @@
     "approximate": true
   },
   {
+    "id": "europe-westX-kronstorf",
+    "locationName": "Kronstorf, Austria",
+    "lat": 48.119927,
+    "lng": 14.455625
+  },
+  {
     "id": "europe-westX-waltham-cross",
     "locationName": "Waltham Cross, United Kingdom",
     "lat": 51.695556,


### PR DESCRIPTION
Added the newly announced Kronstorf, Austria Google Cloud data center location to the tracking data in `src/static/data/gcp-regions.json`. Coordinates were sourced from the provided Google blog post.

---
*PR created automatically by Jules for task [3423702254815142866](https://jules.google.com/task/3423702254815142866) started by @max-ostapenko*